### PR TITLE
Update modularmachinery.zs

### DIFF
--- a/overrides/scripts/mods/modularmachinery.zs
+++ b/overrides/scripts/mods/modularmachinery.zs
@@ -123,6 +123,10 @@ recipes.addShaped(<modularmachinery:blockenergyinputhatch:4>, [
     [null, <contenttweaker:planetshard>, null]
 ]);
 
+// huge energy input hatch
+recipes.addShapeless(<modularmachinery:blockenergyinputhatch:5>>, [
+    <contenttweaker:corruptedstarmetal>, <modularmachinery:blockenergyinputhatch:4>
+]);
 
 ##########################################################################################
 print("==================== end of mods modularmachinery.zs ====================");


### PR DESCRIPTION
Added recipe for Huge Energy Input hatch to enable crafting of Anima Mundi
Requires 20k rf/t but largest energy input hatch only accepts 8k rf/t